### PR TITLE
Fixed bug, now reports actual number of records processed rather than expected.

### DIFF
--- a/onebusaway-nyc-integration-tests/src/test/java/org/onebusaway/nyc/integration_tests/vehicle_tracking_webapp/AbstractTraceRunner.java
+++ b/onebusaway-nyc-integration-tests/src/test/java/org/onebusaway/nyc/integration_tests/vehicle_tracking_webapp/AbstractTraceRunner.java
@@ -156,7 +156,7 @@ public class AbstractTraceRunner {
 
         if (t + _maxTimeout < System.currentTimeMillis()) {
           fail("waited but never received enough records: expected="
-              + expectedResults.size() + " actual=" + expectedResults.size());
+              + expectedResults.size() + " actual=" + ourResults.size());
         }
 
         // We reset our timeout if the record count is growing


### PR DESCRIPTION
very minor bug I noticed when looking at results of failed integration tests.
