### PR TITLE
Fix content-type of JSON API responses to application/json

### DIFF
--- a/onebusaway-nyc-api-webapp/src/main/java/org/onebusaway/api/impl/CustomJsonLibHandler.java
+++ b/onebusaway-nyc-api-webapp/src/main/java/org/onebusaway/api/impl/CustomJsonLibHandler.java
@@ -100,7 +100,7 @@ public class CustomJsonLibHandler implements ContentTypeHandler {
   }
 
   public String getContentType() {
-    return "text/javascript";
+    return "application/json";
   }
 
   public String getExtension() {


### PR DESCRIPTION
An MTA Bus Time API user [reported](https://groups.google.com/d/msg/mtadeveloperresources/XuCZw13v_T4/oGT9aHJIiU8J) that calls to the OneBusAway API were returning JSON responses with a `Content-Type` of `text/javascript`, rather than the expected `application/json`.  This was previously fixed by @barbeau for core OBA in onebusaway/onebusaway-application-modules@78c5067, but the same fix needs to be applied to OBANYC, where the affected module has been renamed `onebusaway-nyc-api-webapp`.
