### PR TITLE
Refactor id of selector element to avoid AdBlock filter

### DIFF
--- a/onebusaway-nyc-admin-webapp/src/main/webapp/WEB-INF/content/admin/sms-webapp-advert.jspx
+++ b/onebusaway-nyc-admin-webapp/src/main/webapp/WEB-INF/content/admin/sms-webapp-advert.jspx
@@ -47,7 +47,7 @@
                 <label class="top">Display sms ad?</label>
                 <s:select class = "ad_update"
                     name="smsShowAd"
-                    id = "showAd"
+                    id ="showAnnouncement"
                     list="#{'false':'hide','true':'display'}"/>
             </fieldset>
             <fieldset class="advert_conditional_display">

--- a/onebusaway-nyc-admin-webapp/src/main/webapp/js/oba/sms-webapp-advert.js
+++ b/onebusaway-nyc-admin-webapp/src/main/webapp/js/oba/sms-webapp-advert.js
@@ -29,8 +29,8 @@ jQuery(function() {
     csrfParameter = $("meta[name='_csrf_parameter']").attr("content");
     csrfHeader = $("meta[name='_csrf_header']").attr("content");
     csrfToken = $("meta[name='_csrf_token']").attr("content");
-    $('#showAd').change(function(){
-        if($('#showAd').val() == 'true') {
+    $('#showAnnouncement').change(function(){
+        if($('#showAnnouncement').val() == 'true') {
             $('.advert_conditional_display').show();
         } else {
             $('.advert_conditional_display').hide();
@@ -138,7 +138,7 @@ function updateParametersView(parameters){
         var configValue = parameters[$(".ad_update")[i].name];
         $(".ad_update")[i].value = configValue;
     }
-    if($('#showAd').val() == 'true') {
+    if($('#showAnnouncement').val() == 'true') {
         $('.advert_conditional_display').show();
     } else {
         $('.advert_conditional_display').hide();


### PR DESCRIPTION
https://camsys.atlassian.net/browse/OBANYC-3141
This drop-down selector element in admin sms ad settings was missing sometimes. The id "showAd" of the selector was being caught by AdBlock's filter lists, causing the element to be blocked. Simply refactoring the id to something else avoids it getting flagged so it won't be blocked.