### PR TITLE
experimental siri api fixes

### DIFF
--- a/onebusaway-nyc-gtfsrt/src/test/java/org/onebusaway/nyc/gtfsrt/tds/MockTransitDataService.java
+++ b/onebusaway-nyc-gtfsrt/src/test/java/org/onebusaway/nyc/gtfsrt/tds/MockTransitDataService.java
@@ -613,7 +613,7 @@ public class MockTransitDataService implements NycTransitDataService {
     }
 
     @Override
-    public Optional<TripModificationDiff> getTripModificationDiff(AgencyAndId tripId, String serviceDate) {
+    public TripModificationDiff getTripModificationDiff(AgencyAndId tripId, String serviceDate) {
         throw new UnsupportedOperationException();
     }
 

--- a/onebusaway-nyc-presentation/src/main/java/org/onebusaway/nyc/presentation/impl/realtime/RealtimeServiceImpl.java
+++ b/onebusaway-nyc-presentation/src/main/java/org/onebusaway/nyc/presentation/impl/realtime/RealtimeServiceImpl.java
@@ -504,9 +504,9 @@ public class RealtimeServiceImpl implements RealtimeService {
     private void setTripDetourStatusExtension(VehicleActivityStructure activity, String tripId, long serviceDateEpochMs) {
         try {
             String serviceDate = new java.text.SimpleDateFormat("yyyyMMdd").format(new Date(serviceDateEpochMs));
-            Optional<TripModificationDiff> diff = _nycTransitDataService
+            TripModificationDiff diff = _nycTransitDataService
                     .getTripModificationDiff(AgencyAndId.convertFromString(tripId), serviceDate);
-            if (diff.isPresent()) {
+            if (diff != null) {
                 SiriTripDetourStatusExtension tripDetourStatus = new SiriTripDetourStatusExtension();
                 tripDetourStatus.setDetour(true);
                 ExtensionsStructure extensions = new ExtensionsStructure();

--- a/onebusaway-nyc-presentation/src/main/java/org/onebusaway/nyc/presentation/impl/realtime/siri/SiriMonitoredVehicleJourneyBuilderServiceImpl.java
+++ b/onebusaway-nyc-presentation/src/main/java/org/onebusaway/nyc/presentation/impl/realtime/siri/SiriMonitoredVehicleJourneyBuilderServiceImpl.java
@@ -243,10 +243,10 @@ public class SiriMonitoredVehicleJourneyBuilderServiceImpl implements SiriMonito
         try {
             String serviceDate = new SimpleDateFormat("yyyyMMdd")
                     .format(new Date(currentlyActiveTripOnBlock.getServiceDate()));
-            Optional<TripModificationDiff> diff = _nycTransitDataService
+            TripModificationDiff diff = _nycTransitDataService
                     .getTripModificationDiff(AgencyAndId.convertFromString(tripOnBlock.getId()), serviceDate);
-            if (diff.isPresent() && diff.get().getChanges() != null) {
-                for (StopChangeDiff change : diff.get().getChanges()) {
+            if (diff != null && diff.getChanges() != null) {
+                for (StopChangeDiff change : diff.getChanges()) {
                     stopChangeMap.put(change.getStopId(), change.getChangeType());
                 }
             }

--- a/onebusaway-nyc-presentation/src/test/java/org/onebusaway/nyc/presentation/impl/realtime/MonitoredVehicleJourneyServiceTest.java
+++ b/onebusaway-nyc-presentation/src/test/java/org/onebusaway/nyc/presentation/impl/realtime/MonitoredVehicleJourneyServiceTest.java
@@ -48,7 +48,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Optional;
 
 import static org.junit.Assert.*;
 import static org.mockito.Matchers.*;
@@ -80,7 +79,7 @@ public class MonitoredVehicleJourneyServiceTest {
     when(nycTransitDataService.getBlockInstance(eq("BLOCK"), anyLong())).thenReturn(blockInstance);
     when(nycTransitDataService.getLastVehicleOccupancyRecordForVehicleId(any(AgencyAndId.class))).thenReturn(null);
     when(nycTransitDataService.stopHasRevenueServiceOnRoute(anyString(),anyString(),anyString(),anyString())).thenReturn(null);
-    when(nycTransitDataService.getTripModificationDiff(any(AgencyAndId.class), anyString())).thenReturn(Optional.empty());
+    when(nycTransitDataService.getTripModificationDiff(any(AgencyAndId.class), anyString())).thenReturn(null);
 
     //when(siriMonitoredCallBuilderService.makeMonitoredCall(any(BlockInstanceBean.class), any(TripBean.class), any(TripStatusBean.class), any(StopBean.class), anyMap(), anyBoolean(), anyLong())).thenReturn(new MonitoredCallStructure());
 

--- a/onebusaway-nyc-transit-data-federation/src/main/java/org/onebusaway/nyc/transit_data_federation/impl/NycTransitDataServiceImpl.java
+++ b/onebusaway-nyc-transit-data-federation/src/main/java/org/onebusaway/nyc/transit_data_federation/impl/NycTransitDataServiceImpl.java
@@ -834,7 +834,11 @@ class NycTransitDataServiceImpl implements NycTransitDataService {
 	}
 
 	@Override
-	public Optional<TripModificationDiff> getTripModificationDiff(AgencyAndId tripId, String serviceDate) {
-		return _transitDataService.getTripModificationDiffs(tripId, parseServiceDate(serviceDate));
+	public TripModificationDiff getTripModificationDiff(AgencyAndId tripId, String serviceDate) {
+		// Pass null as LocalDate to skip the service date filter. effectiveServiceDate in the
+		// cached diff is set at modification-processing time via the block calendar, which can
+		// diverge from the vehicle tracker's serviceDate (e.g. blocks running past midnight).
+		// The cache is keyed by trip ID with one entry per trip, so the filter adds no value.
+		return _transitDataService.getTripModificationDiffs(tripId, null).orElse(null);
 	}
 }

--- a/onebusaway-nyc-transit-data/src/main/java/org/onebusaway/nyc/transit_data/services/NycTransitDataService.java
+++ b/onebusaway-nyc-transit-data/src/main/java/org/onebusaway/nyc/transit_data/services/NycTransitDataService.java
@@ -92,7 +92,7 @@ public interface NycTransitDataService extends TransitDataService {
 
 	Collection<TripModificationDiff> getAllTripModificationDiffs(String serviceDate);
 
-	Optional<TripModificationDiff> getTripModificationDiff(AgencyAndId tripId, String serviceDate);
+	TripModificationDiff getTripModificationDiff(AgencyAndId tripId, String serviceDate);
 
 	Map<AgencyAndId, TripModificationDiff> getAllTripModificationDiffsById(String serviceDate);
 


### PR DESCRIPTION
 Fixes two bugs that prevented trip modification detour data from being surfaced in SIRI Stop Monitoring and Vehicle Monitoring responses.                                       
                                                                                                                                                                                  
  Bug 1 — Hessian EOFException on getTripModificationDiff                                                                                                                         
                                                                                                                                                                                  
  NycTransitDataService.getTripModificationDiff() was declared to return Optional<TripModificationDiff>. This interface is exposed via Spring/Hessian remoting at                 
  /remoting/transit-data-service. Hessian cannot serialize java.util.Optional (it has no public no-arg constructor), causing java.io.EOFException: readObject: unexpected end of 
  file on every call. Fixed by changing the return type to nullable TripModificationDiff and updating all callers to null-check instead of using Optional.isPresent() /           
  Optional.get().                                           

  Bug 2 — Service date mismatch silently dropping valid trip modifications

  TripModificationDiffServiceImpl filters cached diffs by service date using effectiveServiceDate, which is set at modification-processing time by querying the block calendar    
  (getActiveServiceDateForTrip). This value can diverge from the vehicle tracker's serviceDate — most notably for blocks running past midnight, where the block calendar resolves
  to the prior service date while the vehicle tracker reports the current calendar date. The diff was found in the cache but silently filtered out by matchesServiceDate, causing 
  diff == null in buildStopChangeMap. Fixed by passing null as the LocalDate to getTripModificationDiffs, which triggers the existing if (serviceDate == null) return true
  short-circuit in matchesServiceDate, effectively doing a straight trip-ID-only cache lookup. Since the cache stores one entry per trip ID from the live GTFS-RT feed, the date
  filter adds no value.

  Files changed

  - NycTransitDataService — return type Optional<TripModificationDiff> → TripModificationDiff                                                                                     
  - NycTransitDataServiceImpl — unwraps Optional with .orElse(null), bypasses service date filter by passing null
  - SiriMonitoredVehicleJourneyBuilderServiceImpl — null-check instead of Optional                                                                                                
  - RealtimeServiceImpl — null-check instead of Optional                                                                                                                          
  - MockTransitDataService, MonitoredVehicleJourneyServiceTest — updated to match new interface    