### PR TITLE
stop for id api fixes

### DIFF
--- a/onebusaway-nyc-webapp/src/main/java/org/onebusaway/nyc/webapp/actions/api/StopForIdAction.java
+++ b/onebusaway-nyc-webapp/src/main/java/org/onebusaway/nyc/webapp/actions/api/StopForIdAction.java
@@ -15,8 +15,11 @@
  */
 package org.onebusaway.nyc.webapp.actions.api;
 
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Calendar;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.Date;
 import java.util.GregorianCalendar;
 import java.util.List;
@@ -36,6 +39,9 @@ import org.onebusaway.transit_data.model.StopBean;
 import org.onebusaway.transit_data.model.StopGroupBean;
 import org.onebusaway.transit_data.model.StopGroupingBean;
 import org.onebusaway.transit_data.model.StopsForRouteBean;
+import org.onebusaway.transit_data.model.trip_mods.StopChangeDiff;
+import org.onebusaway.transit_data.model.trip_mods.TripModificationDiff;
+import org.onebusaway.transit_data.model.trips.TripBean;
 import org.onebusaway.util.AgencyAndIdLibrary;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -49,7 +55,7 @@ import uk.org.siri.siri.StopMonitoringDeliveryStructure;
 import javax.servlet.http.HttpServletRequest;
 
 public class StopForIdAction extends OneBusAwayNYCActionSupport {
-    
+
   private static final long serialVersionUID = 2L;
 
   @Autowired
@@ -61,67 +67,79 @@ public class StopForIdAction extends OneBusAwayNYCActionSupport {
 
   HttpServletRequest _request;
 
-  private ObjectMapper _mapper = new ObjectMapper();    
+  private ObjectMapper _mapper = new ObjectMapper();
 
   private ServiceAlertsHelper _serviceAlertsHelper = new ServiceAlertsHelper();
 
   private Siri _response = null;
 
   private StopResult _result = null;
-  
+
   private String _stopId = null;
 
   public void setStopId(String stopId) {
     _stopId = stopId;
   }
-  
-  @Override
-  public String execute() {    
-    if(_stopId == null) {
-      return SUCCESS;
-    }
-    
-    StopBean stop = _nycTransitDataService.getStop(_stopId);    
 
-    if(stop == null) {
+  @Override
+  public String execute() {
+    if (_stopId == null) {
       return SUCCESS;
     }
+
+    StopBean stop = _nycTransitDataService.getStop(_stopId);
+
+    if (stop == null) {
+      return SUCCESS;
+    }
+
+    String today = new SimpleDateFormat("yyyyMMdd").format(new Date());
+    Collection<TripModificationDiff> allDiffs =
+            _nycTransitDataService.getAllTripModificationDiffs(today);
 
     List<RouteAtStop> routesAtStop = new ArrayList<RouteAtStop>();
-    for(RouteBean routeBean : stop.getRoutes()) {
+    for (RouteBean routeBean : stop.getRoutes()) {
       StopsForRouteBean stopsForRoute = _nycTransitDataService.getStopsForRoute(routeBean.getId());
 
       List<RouteDirection> routeDirections = new ArrayList<RouteDirection>();
       List<StopGroupingBean> stopGroupings = stopsForRoute.getStopGroupings();
       for (StopGroupingBean stopGroupingBean : stopGroupings) {
         for (StopGroupBean stopGroupBean : stopGroupingBean.getStopGroups()) {
-        	if (_nycTransitDataService.stopHasRevenueServiceOnRoute((routeBean.getAgency()!=null?routeBean.getAgency().getId():null),
-	                    _stopId, routeBean.getId(), stopGroupBean.getId())) {
-        	  
-	          NameBean name = stopGroupBean.getName();
-	          String type = name.getType();
-	
-	          if (!type.equals("destination"))
-	            continue;
-	        
-	          // filter out route directions that don't stop at this stop
-	          if(!stopGroupBean.getStopIds().contains(_stopId))
-	            continue;
-	
-	          Boolean hasUpcomingScheduledService = 
-	        		  _nycTransitDataService.stopHasUpcomingScheduledService((routeBean.getAgency()!=null?routeBean.getAgency().getId():null), System.currentTimeMillis(), stop.getId(), 
-	        				  routeBean.getId(), stopGroupBean.getId());
-	
-	          // if there are buses on route, always have "scheduled service"
-	          Boolean routeHasVehiclesInService = 
-	        		  _realtimeService.getVehiclesInServiceForStopAndRoute(stop.getId(), routeBean.getId(), System.currentTimeMillis());
-	
-	          if(routeHasVehiclesInService) {
-	        	  hasUpcomingScheduledService = true;
-	          }
-	          
-	          routeDirections.add(new RouteDirection(stopGroupBean, null, null, hasUpcomingScheduledService));
-	        }
+          if (_nycTransitDataService.stopHasRevenueServiceOnRoute(
+                  (routeBean.getAgency() != null ? routeBean.getAgency().getId() : null),
+                  _stopId, routeBean.getId(), stopGroupBean.getId())) {
+
+            NameBean name = stopGroupBean.getName();
+            String type = name.getType();
+
+            if (!type.equals("destination"))
+              continue;
+
+            // filter out route directions that don't stop at this stop
+            if (!stopGroupBean.getStopIds().contains(_stopId))
+              continue;
+
+            Boolean hasUpcomingScheduledService =
+                    _nycTransitDataService.stopHasUpcomingScheduledService(
+                            (routeBean.getAgency() != null ? routeBean.getAgency().getId() : null),
+                            System.currentTimeMillis(), stop.getId(),
+                            routeBean.getId(), stopGroupBean.getId());
+
+            // if there are buses on route, always have "scheduled service"
+            Boolean routeHasVehiclesInService =
+                    _realtimeService.getVehiclesInServiceForStopAndRoute(
+                            stop.getId(), routeBean.getId(), System.currentTimeMillis());
+
+            if (routeHasVehiclesInService) {
+              hasUpcomingScheduledService = true;
+            }
+
+            String detourStatus = getStopDetourStatus(
+                    _stopId, routeBean.getId(), stopGroupBean.getId(), allDiffs);
+
+            routeDirections.add(new RouteDirection(stopGroupBean, null, null,
+                    hasUpcomingScheduledService, detourStatus));
+          }
         }
       }
 
@@ -139,25 +157,48 @@ public class StopForIdAction extends OneBusAwayNYCActionSupport {
                 showApc, showRawApc, false);
 
     _response = generateSiriResponse(visits, AgencyAndIdLibrary.convertFromString(_stopId));
-    
+
     return SUCCESS;
-  }   
-  
+  }
+
+  /**
+   * Returns "removed", "detour", or null for a given stop/route/direction
+   * based on today's active trip modifications. Priority: removed > detour.
+   */
+  private String getStopDetourStatus(String stopId, String routeId, String directionId,
+                                     Collection<TripModificationDiff> allDiffs) {
+    if (allDiffs == null || allDiffs.isEmpty()) return null;
+    String result = null;
+    for (TripModificationDiff diff : allDiffs) {
+      TripBean trip = _nycTransitDataService.getTrip(diff.getTripId());
+      if (trip == null || trip.getRoute() == null) continue;
+      if (!routeId.equals(trip.getRoute().getId())) continue;
+      if (!directionId.equals(trip.getDirectionId())) continue;
+      if (diff.getChanges() == null) continue;
+      for (StopChangeDiff change : diff.getChanges()) {
+        if (!stopId.equals(change.getStopId())) continue;
+        if (change.getChangeType() == StopChangeDiff.ChangeType.REMOVED) return "removed";
+        if (change.getChangeType() == StopChangeDiff.ChangeType.ADDED) return "detour";
+      }
+    }
+    return result;
+  }
+
   private Siri generateSiriResponse(List<MonitoredStopVisitStructure> visits, AgencyAndId stopId) {
-    
+
     List<AgencyAndId> stopIds = new ArrayList<AgencyAndId>();
     if (stopId != null) stopIds.add(stopId);
-    
+
     ServiceDelivery serviceDelivery = new ServiceDelivery();
     try {
       StopMonitoringDeliveryStructure stopMonitoringDelivery = new StopMonitoringDeliveryStructure();
       stopMonitoringDelivery.setResponseTimestamp(new Date(getTime()));
-      
+
       Calendar gregorianCalendar = new GregorianCalendar();
       gregorianCalendar.setTimeInMillis(getTime());
       gregorianCalendar.add(Calendar.MINUTE, 1);
       stopMonitoringDelivery.setValidUntil(gregorianCalendar.getTime());
-      
+
       stopMonitoringDelivery.getMonitoredStopVisit().addAll(visits);
 
       serviceDelivery.setResponseTimestamp(new Date(getTime()));
@@ -171,21 +212,21 @@ public class StopForIdAction extends OneBusAwayNYCActionSupport {
 
     Siri siri = new Siri();
     siri.setServiceDelivery(serviceDelivery);
-    
+
     return siri;
   }
-  
-  /** 
+
+  /**
    * VIEW METHODS
    */
   public String getStopMonitoring() {
     try {
       return _realtimeService.getSiriJsonSerializer().getJson(_response, null);
-    } catch(Exception e) {
+    } catch (Exception e) {
       return e.getMessage();
     }
   }
-  
+
   public String getStopMetadata() throws Exception {
     return _mapper.writeValueAsString(_result);
   }

--- a/onebusaway-nyc-webapp/src/main/java/org/onebusaway/nyc/webapp/actions/api/model/RouteDirection.java
+++ b/onebusaway-nyc-webapp/src/main/java/org/onebusaway/nyc/webapp/actions/api/model/RouteDirection.java
@@ -37,6 +37,8 @@ public class RouteDirection {
 
   private Boolean hasUpcomingScheduledService;
 
+  private String detourStatus;
+
   public RouteDirection(StopGroupBean stopGroup, List<String> polylines,
                         List<StopOnRoute> stops, Boolean hasUpcomingScheduledService) {
     this.directionId = stopGroup.getId();
@@ -44,6 +46,13 @@ public class RouteDirection {
     this.polylines = polylines;
     this.stops = stops;
     this.hasUpcomingScheduledService = hasUpcomingScheduledService;
+  }
+
+  public RouteDirection(StopGroupBean stopGroup, List<String> polylines,
+                        List<StopOnRoute> stops, Boolean hasUpcomingScheduledService,
+                        String detourStatus) {
+    this(stopGroup, polylines, stops, hasUpcomingScheduledService);
+    this.detourStatus = detourStatus;
   }
 
   public String getDirectionId() {
@@ -64,6 +73,10 @@ public class RouteDirection {
 
   public Boolean getHasUpcomingScheduledService() {
     return hasUpcomingScheduledService;
+  }
+
+  public String getDetourStatus() {
+    return detourStatus;
   }
 
 }


### PR DESCRIPTION
Adds a detourStatus field to each route direction in the stopMetadata response of the stop-for-id API in addition to the existing MonitoredCall and OnwardCalls, StopDetourStatus.IsDetour flag
   
  **New field**                                                                                                                                                                                                                  
  routesAvailable[].directions[].detourStatus — possible values:                                                                                                                  
   
  - "removed" — stop is skipped by an active trip modification                                                                                                                    
  - "detour" — stop has been added by an active trip modification
  - null — no active modification affects this stop for this route/direction
